### PR TITLE
fix review_assign.yml

### DIFF
--- a/.github/workflows/review_assign.yml
+++ b/.github/workflows/review_assign.yml
@@ -4,19 +4,34 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   assign:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    # https://qiita.com/hkusu/items/39eb92dbd4d6db8a14d8
     steps:
-      # ランダムでレビュアーをアサイン
-      - uses: hkusu/review-assign-action@v1
+      - name: Set assignees
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          assignees: ${{ github.actor }}
-          reviewers: ${{ vars.REVIEWERS }}
-          max-num-of-reviewers: 2
-          draft-keyword: wip
+          ASSIGNEES: "${{ github.actor }}"
+        run: |
+          assignee_count=$(cat ${{ github.event_path }} | jq '.pull_request.assignees | length')
+          if [[ 0 == $assignee_count ]]; then
+            assignees=$(echo "\"${ASSIGNEES// /}\"" | jq 'split(",")')
+            curl -X POST \
+                 -H "Content-Type: application/json" \
+                 -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                 -d "{ \"assignees\": $assignees }" \
+                 https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/assignees
+          fi
+      - name: Set reviewers
+        env:
+          REVIEWERS: ${{ vars.REVIEWERS }} # edit here
+        run: |
+          reviewer_count=$(cat ${{ github.event_path }} | jq '.pull_request.requested_reviewers | length')
+          if [[ 0 == $reviewer_count ]]; then
+            reviewers=$(echo "\"${REVIEWERS// /}\"" | jq 'split(",") | .-["${{ github.actor }}"]')
+            curl -X POST \
+                 -H "Content-Type: application/json" \
+                 -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                 -d "{ \"reviewers\": $reviewers }" \
+                 https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers
+          fi

--- a/.github/workflows/review_assign.yml
+++ b/.github/workflows/review_assign.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       # ランダムでレビュアーをアサイン
       - uses: hkusu/review-assign-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           assignees: ${{ github.actor }}
           reviewers: ${{ vars.REVIEWERS }}


### PR DESCRIPTION
Actionsエラー対応
~トークンの所で指摘されているのでsecrets.GITHUB_TOKENを使ってみる~ これだけだとダメでした
> GitHub API error (message: Request failed with status code 403). "github-token" may not be correct.

[こちら](https://qiita.com/hkusu/items/39eb92dbd4d6db8a14d8)を参考に直でGITHUB APIを叩いてみる